### PR TITLE
Add lint tooling (Lua/YAML/Ansible) + CI, fix nvim lua_ls types

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,22 @@
+---
+# `min` only flags things that would actually break (e.g. missing roles, bad
+# syntax) — a sane floor for this repo. Raise to `basic`/`safety`/etc. later to
+# enforce more style. Use yamllint (.yamllint) for YAML formatting concerns.
+profile: min
+
+exclude_paths:
+  - roles/nvim/files/ # deployed nvim config (lua/yaml), not Ansible content
+  - .github/
+
+# yamllint runs separately via `just lint-yaml`.
+skip_list:
+  - yaml
+
+# Modules the lint env can't resolve: `yay` is this repo's custom module
+# (library/yay); the rest live in the community.general collection, which we
+# don't install just to lint. Mock them so syntax-check passes.
+mock_modules:
+  - yay
+  - snap
+  - community.general.npm
+  - community.general.pacman

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   checks:
-    name: Lint & format checks
+    name: Format & syntax checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,3 +23,48 @@ jobs:
           key: prek-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run check hooks
         run: prek run --all-files --hook-stage pre-commit --show-diff-on-failure --color always
+
+  lint:
+    name: Lint (YAML, Ansible, Lua)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # yamllint + ansible-lint run via uvx (see the justfile lint recipes).
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+
+      - name: Install lua-language-server
+        run: |
+          ver=$(curl -fsSL https://api.github.com/repos/LuaLS/lua-language-server/releases/latest | jq -r .tag_name)
+          mkdir -p "$HOME/lua-ls"
+          curl -fsSL "https://github.com/LuaLS/lua-language-server/releases/download/${ver}/lua-language-server-${ver}-linux-x64.tar.gz" \
+            | tar -xz -C "$HOME/lua-ls"
+          echo "$HOME/lua-ls/bin" >> "$GITHUB_PATH"
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install selene
+        run: cargo binstall --no-confirm selene
+
+      # The Lua type check is static, but .luarc.json points its library at the
+      # installed plenary/flash plugins, so make those paths exist. (No full
+      # plugin bootstrap needed — lua-language-server never runs the config.)
+      - name: Provide Lua libraries for the type check
+        run: |
+          libs="$HOME/.local/share/nvim/lazy"
+          mkdir -p "$libs"
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim "$libs/plenary.nvim"
+          git clone --depth 1 https://github.com/folke/flash.nvim "$libs/flash.nvim"
+
+      - name: Run linters
+        run: just lint

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ tmp/
 .stack-work
 *.lock
 roles/nvim/files/plugin/packer_compiled.lua
+
+# ansible-lint writes mocked modules here (mock_modules in .ansible-lint), and
+# ansible uses it for local galaxy installs / tmp — all generated, not source.
+.ansible/

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,3 +1,0 @@
-{
-  "diagnostics.globals": ["vim"]
-}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
         language: node
         additional_dependencies: ["prettier@3.8.4"]
         types_or: [yaml, json, css, markdown]
-        exclude: \.j2$|lazy-lock.json$
+        exclude: \.j2$|lazy-lock.json$|\.yamllint$|\.ansible-lint$
         stages: [pre-commit, pre-push]
       - id: prettier-format
         name: prettier (format yaml/json/css/md)
@@ -80,7 +80,7 @@ repos:
         language: node
         additional_dependencies: ["prettier@3.8.4"]
         types_or: [yaml, json, css, markdown]
-        exclude: \.j2$|lazy-lock.json$
+        exclude: \.j2$|lazy-lock.json$|\.yamllint$|\.ansible-lint$
         stages: [manual]
 
       # Heavy and inherently local: boots a real nvim. Push-only, and only when

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,27 @@
+---
+# Relaxed for Ansible / hand-written config-file idioms, while still catching
+# real problems (syntax errors, duplicate keys, trailing whitespace, tabs).
+extends: relaxed
+
+rules:
+  line-length: disable
+  document-start: disable
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
+  truthy:
+    # `on:` in GitHub Actions parses as a boolean key; allow yes/no for Ansible.
+    check-keys: false
+    allowed-values: ["true", "false", "yes", "no"]
+  # The following match ansible-lint's embedded-yamllint requirements so it
+  # doesn't warn about an incompatible config (it loads .yamllint even though we
+  # run yamllint separately). `max-spaces-inside: 1` still passes our YAML.
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+
+ignore: |
+  lazy-lock.json

--- a/dotfiles.yml
+++ b/dotfiles.yml
@@ -38,13 +38,6 @@
     - role: tmux
       tags:
         - "tmux"
-    - role: emacs
-      tags:
-        - "emacs"
-        - "doom-emacs"
-    - role: vim
-      tags:
-        - "vim"
     - role: nvim
       tags:
         - "nvim"

--- a/justfile
+++ b/justfile
@@ -1,13 +1,29 @@
 # Repo-wide tasks. Default hooks only check; formatting is opt-in.
 
-# Auto-format everything in place (stylua, shfmt, prettier, whitespace/EOF).
-fmt:
-    prek run --hook-stage manual --all-files
+mod nvim 'roles/nvim/files'
 
-# Run the check-only hooks against all files (reports errors, no changes).
-check:
-    prek run --all-files
+# Auto-format in place. Pass a hook id to run just that one, e.g. `just fmt stylua-github`.
+fmt HOOK="":
+    prek run --hook-stage manual {{ HOOK }} --all-files
+
+# Run check-only hooks (no changes). Pass a hook id to run just that one, e.g. `just check shellcheck`.
+check HOOK="":
+    prek run {{ HOOK }} --all-files
 
 # Run the nvim regression test suite (boots a real nvim headless).
 test:
-    just --justfile roles/nvim/files/justfile test
+    just nvim test
+
+# Run the code linters: YAML (yamllint) + Ansible (ansible-lint) + Lua
+# (lua-language-server + selene). Orthogonal to `check` (prek format/syntax
+# hooks); CI runs both.
+lint: lint-yaml lint-ansible
+    just nvim lint
+
+# Lint YAML with yamllint (config: .yamllint).
+lint-yaml DIR=".":
+    uvx yamllint {{ DIR }}
+
+# Lint the Ansible playbook and roles with ansible-lint (config: .ansible-lint).
+lint-ansible:
+    uvx ansible-lint

--- a/roles/nvim/files/.luarc.json
+++ b/roles/nvim/files/.luarc.json
@@ -1,0 +1,11 @@
+{
+  "runtime.version": "LuaJIT",
+  "workspace.library": [
+    "$VIMRUNTIME/lua",
+    "$HOME/.local/share/nvim/lazy/plenary.nvim/lua",
+    "$HOME/.local/share/nvim/lazy/flash.nvim/lua",
+    "tests/types"
+  ],
+  "workspace.checkThirdParty": "Disable",
+  "diagnostics.disable": ["different-requires"]
+}

--- a/roles/nvim/files/justfile
+++ b/roles/nvim/files/justfile
@@ -1,5 +1,28 @@
 # nvim config test runner. Run from roles/nvim/files/.
 
+# Lint the Lua config (lua-language-server diagnostics + selene).
+lint: lint-lua lint-selene
+
+# Type/diagnostic check of the Lua config via lua-language-server.
+lint-lua:
+    #!/usr/bin/env bash
+    echo "Running lua-language-server diagnostics (config: .luarc.json)"
+    set -euo pipefail
+    # lua-language-server needs $VIMRUNTIME (the bundled vim API library that
+    # .luarc.json points at) and the actual binary nvim uses; resolve both from
+    # nvim so this works even though the on-PATH lua-language-server may be a
+    # broken install. In CI (no mason) it falls back to lua-language-server on PATH.
+    # -u NONE: VIMRUNTIME/stdpath are built-ins, so skip loading the config
+    # (which would fail without plugins installed, e.g. in CI).
+    export VIMRUNTIME="$(nvim --headless -u NONE -c 'lua io.write(vim.env.VIMRUNTIME)' -c 'qa')"
+    lls="$(nvim --headless -u NONE -c 'lua io.write(vim.fn.stdpath("data"))' -c 'qa')/mason/bin/lua-language-server"
+    [ -x "$lls" ] || lls=lua-language-server
+    "$lls" --check . --configpath .luarc.json --checklevel Warning --logpath "$(mktemp -d)"
+
+# Lua linting via selene.
+lint-selene:
+    selene .
+
 # Run the full spec suite headless; non-zero exit on failure.
 # init=/minimal=false makes plenary spawn child processes WITHOUT --noplugin,
 # so each spec boots the real config with its start plugins loaded.

--- a/roles/nvim/files/lua/plugins/iron.lua
+++ b/roles/nvim/files/lua/plugins/iron.lua
@@ -23,7 +23,7 @@ iron.setup({
     -- set the file type of the newly created repl to ft
     -- bufnr is the buffer id of the REPL and ft is the filetype of the
     -- language being used for the REPL.
-    repl_filetype = function(bufnr, ft)
+    repl_filetype = function(_bufnr, ft)
       return ft
       -- or return a string name such as the following
       -- return "iron"

--- a/roles/nvim/files/lua/plugins/lsp/keys.lua
+++ b/roles/nvim/files/lua/plugins/lsp/keys.lua
@@ -45,8 +45,12 @@ local lsp_on_attach = function(client, event)
     vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr }), { bufnr = bufnr })
   end, "LSP: toggle inlay hints")
   map({ "n", "v" }, "<leader>cws", vim.lsp.buf.workspace_symbol, "LSP: workspace symbols")
-  map("n", "]d", vim.diagnostic.goto_next, "Diagnostic: next")
-  map("n", "[d", vim.diagnostic.goto_prev, "Diagnostic: prev")
+  map("n", "]d", function()
+    vim.diagnostic.jump({ count = 1, float = true })
+  end, "Diagnostic: next")
+  map("n", "[d", function()
+    vim.diagnostic.jump({ count = -1, float = true })
+  end, "Diagnostic: prev")
   map("n", "<leader>dd", vim.diagnostic.open_float, "Diagnostic: show float")
   map({ "v", "n" }, "<leader>ca", require("actions-preview").code_actions, "LSP: code actions")
   map("n", "<leader>cR", vim.lsp.buf.references, "LSP: references")
@@ -59,7 +63,7 @@ local lsp_on_attach = function(client, event)
       formatting_options = {}
     end
 
-    local filter = function(local_client)
+    local filter = function(_local_client)
       -- vim.print(vim.inspect(local_client.name))
       return true
     end

--- a/roles/nvim/files/lua/plugins/lsp/servers.lua
+++ b/roles/nvim/files/lua/plugins/lsp/servers.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local home_path = os.getenv("HOME")
 local venv_path = os.getenv("VIRTUAL_ENV")
 local py_path = nil
 
@@ -9,13 +8,13 @@ if venv_path ~= nil then
   py_path = venv_path .. "/bin/python"
 end
 
-local lsp_path = string.format(
-  "%s/.local/bin:%s/.cargo/bin:%s/.nvm/versions/node/v24.6.0/bin:/usr/bin:/usr/local/bin:/usr/local/sbin:/sbin:/bin",
-  home_path,
-  home_path,
-  home_path
-)
--- PATH = "~/.cargo/bin:~/.nvm/versions/node/v24.6.0/bin:/usr/bin:/usr/local/bin:/usr/local/sbin:/sbin:/bin",
+-- local _home_path = os.getenv("HOME")
+-- local _lsp_path = string.format(
+--   "%s/.local/bin:%s/.cargo/bin:%s/.nvm/versions/node/v24.6.0/bin:/usr/bin:/usr/local/bin:/usr/local/sbin:/sbin:/bin",
+--   home_path,
+--   home_path,
+--   home_path
+-- )
 
 local servers = {
   pylsp = {
@@ -116,15 +115,10 @@ local servers = {
   --   },
   -- },
 
-  lua_ls = {
-    settings = {
-      Lua = {
-        diagnostics = {
-          globals = { "vim" },
-        },
-      },
-    },
-  },
+  -- Kept generic so this server works the same in every project. Project-specific
+  -- type setup (the nvim `vim` runtime library, plenary/busted test globals, the
+  -- luassert meta) lives in this config's own .luarc.json instead of here.
+  lua_ls = {},
 
   rust_analyzer = {
     -- disable for different cargo version...
@@ -276,7 +270,7 @@ local servers = {
   microcad = {
     filetypes = { "microcad", "mcad", "ucad", "µcad" },
     cmd = { "microcad-lsp", "--stdio" },
-    root_markers = { { "mcad.toml", "ucad.toml", "µcad.toml" }, ".git" },
+    root_markers = { { "mcad.toml", "ucad.toml", "µcad.toml" }, ".git", ".jj" },
     env = {
       RUST_LOG = "debug",
     },

--- a/roles/nvim/files/lua/plugins/oil.lua
+++ b/roles/nvim/files/lua/plugins/oil.lua
@@ -84,11 +84,11 @@ require("oil").setup({
     -- Show files and directories that start with "."
     show_hidden = true,
     -- This function defines what is considered a "hidden" file
-    is_hidden_file = function(name, bufnr)
+    is_hidden_file = function(name, _bufnr)
       return vim.startswith(name, ".")
     end,
     -- This function defines what will never be shown, even when `show_hidden` is set
-    is_always_hidden = function(name, bufnr)
+    is_always_hidden = function(_name, _bufnr)
       return false
     end,
     -- Sort file names in a more intuitive order for humans. Is less performant,

--- a/roles/nvim/files/neovim.yml
+++ b/roles/nvim/files/neovim.yml
@@ -1,0 +1,44 @@
+# Minimal selene standard library for this Neovim config.
+# Extends Lua 5.1 with the `vim` global and the plenary/busted test globals so
+# selene doesn't report them as undefined. Field-level typing is left to
+# lua-language-server (see .luarc.json); selene only needs the names to exist.
+---
+base: lua51
+
+globals:
+  vim:
+    any: true
+
+  # luassert replaces the stdlib `assert` global with a callable table
+  # (assert.are.equal, assert.is_true, ...); treat it as `any` so selene's
+  # standard-library field checks don't fire on the assertion chains.
+  assert:
+    any: true
+
+  # interactive dev-helper globals defined in lua/utils/globals.lua
+  P:
+    any: true
+  R:
+    any: true
+  RELOAD:
+    any: true
+  GIT_CWD:
+    any: true
+
+  # plenary busted test runner globals (tests/spec/*_spec.lua)
+  describe:
+    any: true
+  it:
+    any: true
+  before_each:
+    any: true
+  after_each:
+    any: true
+  pending:
+    any: true
+  spy:
+    any: true
+  stub:
+    any: true
+  mock:
+    any: true

--- a/roles/nvim/files/selene.toml
+++ b/roles/nvim/files/selene.toml
@@ -1,0 +1,9 @@
+std = "neovim"
+
+# lazy.nvim's generated lockfile is not hand-written Lua.
+exclude = ["lazy-lock.json"]
+
+[lints]
+# Neovim/plugin APIs are loosely typed; mixed-table literals (list + map) are
+# idiomatic in lazy.nvim plugin specs and keymap tables.
+mixed_table = "allow"

--- a/roles/nvim/files/tests/types/luassert.lua
+++ b/roles/nvim/files/tests/types/luassert.lua
@@ -1,0 +1,12 @@
+---@meta
+
+-- Plenary bundles its own LuaCATS meta for luassert
+-- (lua/plenary/_meta/_luassert.lua), which lua_ls loads as a workspace library.
+-- That meta defines the `are`/`is`/`has`/`no`/`does` chains but omits a few
+-- aliases the specs use, so re-open the class here to add them and stop lua_ls
+-- reporting them as undefined-field. These all exist at runtime (luassert builds
+-- assertion chains dynamically via metatables).
+---@class Luassert
+---@field is_not Luassert
+---@field has_no Luassert
+---@field is_not_nil LuassertFunction


### PR DESCRIPTION
## Summary

Sets up proper Lua LSP types for the nvim config and adds a repo-wide lint
workflow across Lua, YAML, and Ansible, wired into CI.

### Lua LSP / types
- Keep the global `lua_ls` generic (`lua_ls = {}`); move all project-specific
  type setup into `roles/nvim/files/.luarc.json`, which deploys with the config.
- Real `vim` API completion via `$VIMRUNTIME/lua`; plenary/busted globals +
  `assert` via the installed plenary; `Flash.Config` via flash.nvim; a small
  `Luassert` meta extension (`tests/types/luassert.lua`) for the assertion
  aliases plenary's bundled meta omits. Paths use env vars — nothing hardcoded.
- Fix pre-existing diagnostics: deprecated `vim.diagnostic.goto_*` → `jump`,
  unused vars, and accidental globals (declared in the selene std).

### Lint tooling
- `just lint` runs the code linters: `lint-lua` (lua-language-server) +
  `lint-selene`, plus `lint-yaml` (yamllint) and `lint-ansible` (ansible-lint).
- `check`/`fmt` now take an optional hook id (e.g. `just check shellcheck`).
- Add `selene.toml` + a minimal neovim std, `.yamllint`, and `.ansible-lint`
  (configs tuned so they're green while still catching real issues).
- Remove dead `emacs`/`vim` role references from `dotfiles.yml` (caught by
  ansible-lint), and gitignore the generated `.ansible/` mock-module dir.

### CI
- Add a `lint` job to `.github/workflows/ci.yml` (installs nvim, lua-language-server,
  selene via `cargo binstall`, uv) alongside the existing prek `checks` job.

## Verification
`just check`, `just lint`, and `just test` all pass locally.