### PR TITLE
refactor(ansible): fix deprecation warnings for top-level facts; ignore packer_compiled in lua linter

### DIFF
--- a/dotfiles.yml
+++ b/dotfiles.yml
@@ -6,7 +6,7 @@
   hosts: local
   tasks:
     - debug:
-        var: ansible_os_family
+        var: ansible_facts.os_family
         verbosity: 1
       tags:
         - "git"

--- a/roles/firefox/tasks/main.yml
+++ b/roles/firefox/tasks/main.yml
@@ -18,7 +18,7 @@
     profiles_dir: >-
       {{
         (found_profiles_ini | dirname ~ '/Profiles')
-        if (ansible_os_family == 'Darwin')
+        if (ansible_facts.os_family == 'Darwin')
         else (found_profiles_ini | dirname)
       }}
   when: found_profiles_ini != ""

--- a/roles/fzf/tasks/main.yml
+++ b/roles/fzf/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Update fzf
   git:

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Check if gitconfig exists
   stat: path="{{dotfiles_user_home}}/.gitconfig"

--- a/roles/haskell/tasks/main.yml
+++ b/roles/haskell/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: create stack directory
   file:

--- a/roles/nvim/files/.luarc.json
+++ b/roles/nvim/files/.luarc.json
@@ -7,8 +7,6 @@
     "tests/types"
   ],
   "workspace.checkThirdParty": "Disable",
-  "workspace.ignoreDir": [
-    "plugin/packer_compiled.lua"
-  ],
+  "workspace.ignoreDir": ["plugin/packer_compiled.lua"],
   "diagnostics.disable": ["different-requires"]
 }

--- a/roles/nvim/files/.luarc.json
+++ b/roles/nvim/files/.luarc.json
@@ -7,5 +7,8 @@
     "tests/types"
   ],
   "workspace.checkThirdParty": "Disable",
+  "workspace.ignoreDir": [
+    "plugin/packer_compiled.lua"
+  ],
   "diagnostics.disable": ["different-requires"]
 }

--- a/roles/nvim/files/selene.toml
+++ b/roles/nvim/files/selene.toml
@@ -1,7 +1,7 @@
 std = "neovim"
 
 # lazy.nvim's generated lockfile is not hand-written Lua.
-exclude = ["lazy-lock.json"]
+exclude = ["lazy-lock.json", "plugin/packer_compiled.lua"]
 
 [lints]
 # Neovim/plugin APIs are loosely typed; mixed-table literals (list + map) are

--- a/roles/nvim/tasks/main.yml
+++ b/roles/nvim/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Install bob-nvim with cargo-binstall
   command: "{{ dotfiles_user_home }}/.cargo/bin/cargo-binstall -y bob-nvim"

--- a/roles/packages/tasks/debian.yml
+++ b/roles/packages/tasks/debian.yml
@@ -4,15 +4,15 @@
     dest: "/etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
   become: true
   become_method: sudo
-  when: ansible_distribution_version == "20.04"
+  when: ansible_facts.distribution_version == "20.04"
 
 - name: Install podman apt-key
   apt_key:
-    url: "https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_{{ ansible_distribution_version }}/Release.key"
+    url: "https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_{{ ansible_facts.distribution_version }}/Release.key"
     state: present
   become: true
   become_method: sudo
-  when: ansible_distribution_version == "20.04"
+  when: ansible_facts.distribution_version == "20.04"
 
 - name: Download 1Password GPG key
   get_url:

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -1,7 +1,7 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 - include_tasks: arch.yml
-  when: ansible_os_family == "Archlinux"
+  when: ansible_facts.os_family == "Archlinux"
 
 - name: Install global npm packages to user local bin
   block:
@@ -9,7 +9,7 @@
       community.general.npm:
         name: "bash-language-server"
         global: true
-      when: ansible_os_family != "Archlinux"
+      when: ansible_facts.os_family != "Archlinux"
 
     - name: install prettier
       community.general.npm:
@@ -21,7 +21,7 @@
       community.general.npm:
         name: "@mermaid-js/mermaid-cli"
         global: true
-      when: ansible_os_family != "Archlinux"
+      when: ansible_facts.os_family != "Archlinux"
   environment:
     NPM_CONFIG_PREFIX: "{{ dotfiles_user_home }}/.local"
   when: not ansible_check_mode

--- a/roles/penrose/tasks/main.yml
+++ b/roles/penrose/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: Fetch penrose (favilrose) git repo
   git:

--- a/roles/programming/tasks/main.yml
+++ b/roles/programming/tasks/main.yml
@@ -1,7 +1,7 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 - include_tasks: arch.yml
-  when: ansible_os_family == "Archlinux"
+  when: ansible_facts.os_family == "Archlinux"
 
 - name: download rustup
   get_url:

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -1,7 +1,7 @@
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 - include_tasks: arch.yml
-  when: ansible_os_family == "Archlinux"
+  when: ansible_facts.os_family == "Archlinux"
 
 - name: download oh-my-zsh installer
   get_url:


### PR DESCRIPTION
Fixes deprecation warnings for top-level facts in ansible tasks, and excludes plugin/packer_compiled.lua from lua-language-server and selene lint checks.