### PR TITLE
feat(zellij): add visible orange pane borders

### DIFF
--- a/roles/zellij/files/config.kdl
+++ b/roles/zellij/files/config.kdl
@@ -298,7 +298,7 @@ load_plugins {
 // Choose the theme that is specified in the themes section.
 // Default: default
 //
-theme "nightfox"
+theme "nightfox-orange"
 
 // Choose the base input mode of zellij.
 // Default: normal
@@ -324,10 +324,10 @@ default_shell "zsh"
 //
 // layout_dir "/tmp"
 
-// The folder in which Zellij will look for themes
-// (Requires restart)
-//
-// theme_dir "/tmp"
+// The folder in which Zellij will look for themes.
+// Explicitly set because Zellij 0.44.0 otherwise scans the config directory
+// itself instead of its themes subdirectory when loading a session.
+theme_dir "/home/favilo/.config/zellij/themes"
 
 // Toggle enabling the mouse mode.
 // On certain configurations, or terminals this could

--- a/roles/zellij/files/nightfox-orange.kdl
+++ b/roles/zellij/files/nightfox-orange.kdl
@@ -1,0 +1,120 @@
+themes {
+    nightfox-orange {
+        text_unselected {
+            base 174 175 176
+            background 41 57 79
+            emphasis_0 244 162 97
+            emphasis_1 99 205 207
+            emphasis_2 129 178 154
+            emphasis_3 157 121 214
+        }
+        text_selected {
+            base 174 175 176
+            background 41 57 79
+            emphasis_0 244 162 97
+            emphasis_1 99 205 207
+            emphasis_2 129 178 154
+            emphasis_3 157 121 214
+        }
+        ribbon_selected {
+            base 41 57 79
+            background 129 178 154
+            emphasis_0 201 79 109
+            emphasis_1 244 162 97
+            emphasis_2 157 121 214
+            emphasis_3 113 156 214
+        }
+        ribbon_unselected {
+            base 41 57 79
+            background 205 206 207
+            emphasis_0 201 79 109
+            emphasis_1 174 175 176
+            emphasis_2 113 156 214
+            emphasis_3 157 121 214
+        }
+        table_title {
+            base 129 178 154
+            background 0
+            emphasis_0 244 162 97
+            emphasis_1 99 205 207
+            emphasis_2 129 178 154
+            emphasis_3 157 121 214
+        }
+        table_cell_selected {
+            base 174 175 176
+            background 25 35 48
+            emphasis_0 244 162 97
+            emphasis_1 99 205 207
+            emphasis_2 129 178 154
+            emphasis_3 157 121 214
+        }
+        table_cell_unselected {
+            base 174 175 176
+            background 41 57 79
+            emphasis_0 244 162 97
+            emphasis_1 99 205 207
+            emphasis_2 129 178 154
+            emphasis_3 157 121 214
+        }
+        list_selected {
+            base 174 175 176
+            background 25 35 48
+            emphasis_0 244 162 97
+            emphasis_1 99 205 207
+            emphasis_2 129 178 154
+            emphasis_3 157 121 214
+        }
+        list_unselected {
+            base 174 175 176
+            background 41 57 79
+            emphasis_0 244 162 97
+            emphasis_1 99 205 207
+            emphasis_2 129 178 154
+            emphasis_3 157 121 214
+        }
+        frame_selected {
+            base 227 150 62
+            background 0
+            emphasis_0 227 150 62
+            emphasis_1 227 150 62
+            emphasis_2 227 150 62
+            emphasis_3 227 150 62
+        }
+        frame_highlight {
+            base 227 150 62
+            background 0
+            emphasis_0 227 150 62
+            emphasis_1 227 150 62
+            emphasis_2 227 150 62
+            emphasis_3 227 150 62
+        }
+        exit_code_success {
+            base 129 178 154
+            background 0
+            emphasis_0 99 205 207
+            emphasis_1 41 57 79
+            emphasis_2 157 121 214
+            emphasis_3 113 156 214
+        }
+        exit_code_error {
+            base 201 79 109
+            background 0
+            emphasis_0 219 192 116
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 157 121 214
+            player_2 113 156 214
+            player_3 0
+            player_4 219 192 116
+            player_5 99 205 207
+            player_6 0
+            player_7 201 79 109
+            player_8 0
+            player_9 0
+            player_10 0
+        }
+    }
+}

--- a/roles/zellij/tasks/main.yml
+++ b/roles/zellij/tasks/main.yml
@@ -9,9 +9,21 @@
     path: "{{ xdg_config_home }}/zellij"
     state: directory
 
+- name: Create zellij themes directory
+  file:
+    path: "{{ xdg_config_home }}/zellij/themes"
+    state: directory
+
 - name: Link zellij config.kdl
   file:
     src: "{{ dotfiles_home }}/roles/zellij/files/config.kdl"
     dest: "{{ xdg_config_home }}/zellij/config.kdl"
+    state: link
+    force: true
+
+- name: Link custom zellij theme
+  file:
+    src: "{{ dotfiles_home }}/roles/zellij/files/nightfox-orange.kdl"
+    dest: "{{ xdg_config_home }}/zellij/themes/nightfox-orange.kdl"
     state: link
     force: true

--- a/roles/zsh/files/zshrc
+++ b/roles/zsh/files/zshrc
@@ -141,5 +141,3 @@ fi
 
 
 
-# Added by Antigravity CLI installer
-export PATH="/home/favilo/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
<!-- bigpowers-provenance: agent-generated -->

- add a Nightfox-derived Zellij theme with visible orange pane borders
- install the custom theme through the Zellij Ansible role
- remove a redundant `~/.local/bin` PATH declaration from the main zshrc

## Test plan
- [x] `just check`
- [x] `just dry-run --tags zellij,zsh`
- [x] `zellij setup --check`
- [x] `uvx yamllint roles/zellij/tasks/main.yml`
- [x] `uvx ansible-lint roles/zellij/tasks/main.yml`